### PR TITLE
142-fix/add-funding-source-modal-closure

### DIFF
--- a/src/modules/project-editor/components/AddFundingSourceModal.tsx
+++ b/src/modules/project-editor/components/AddFundingSourceModal.tsx
@@ -75,7 +75,10 @@ const AddFundingSourceModal = ({
 
   return (
     <Dialog open={open}>
-      <DialogContent className="max-w-130" onCloseClick={onCloseHandler}>
+      <DialogContent
+        className="max-w-130 max-h-screen"
+        onCloseClick={onCloseHandler}
+      >
         <DialogHeader>
           <DialogTitle>
             {isEdit ? "Edit Funding Source" : "Add Funding Source"}
@@ -89,7 +92,7 @@ const AddFundingSourceModal = ({
                 ? onSubmitEditedFundingSourceHandler
                 : onSubmitFundingSourceHandler,
             )}
-            className="flex flex-col p-6"
+            className="flex h-full flex-col overflow-y-scroll p-6"
           >
             <FormField
               control={form.control}


### PR DESCRIPTION
- Reesolves #142 
- Sets a max height for Add funding source modal and adds scroll to overflowing content
<img width="1115" alt="Screenshot 2024-10-25 at 12 46 02 pm" src="https://github.com/user-attachments/assets/c830f76c-dd9e-4827-88a6-d093cbb2fe96">
<img width="1128" alt="Screenshot 2024-10-25 at 12 46 11 pm" src="https://github.com/user-attachments/assets/033d63e1-5d15-4479-a27f-c52f482fc672">
<img width="1044" alt="Screenshot 2024-10-25 at 12 46 28 pm" src="https://github.com/user-attachments/assets/aa4eb0ef-8c76-44a7-9185-08ba38cfc0ac">

