### PR TITLE
fix: Unlock donation submit with default value

### DIFF
--- a/src/features/donation/hooks/forms.ts
+++ b/src/features/donation/hooks/forms.ts
@@ -136,7 +136,7 @@ export const useDonationForm = ({ referrerAccountId, ...params }: DonationFormPa
     [defaultValues, values],
   );
 
-  const isDisabled = !hasChanges || !self.formState.isValid || self.formState.isSubmitting;
+  const isDisabled = !self.formState.isValid || self.formState.isSubmitting;
 
   const minAmountError =
     !isDonationAmountSufficient({ amount, tokenId }) && hasChanges


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Adjusted the donation form’s behavior so that its availability now depends solely on input validity and submission progress, ensuring a more consistent and responsive experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->