### PR TITLE
Change Campaign Contract Name for Prod Env

### DIFF
--- a/src/common/_config/production.env-config.ts
+++ b/src/common/_config/production.env-config.ts
@@ -15,7 +15,7 @@ export const envConfig: EnvConfig = {
 
   core: {
     campaigns: {
-      contract: { accountId: "campaigns.staging.potlock.near" },
+      contract: { accountId: "v1.campaigns.staging.potlock.near" },
     },
 
     donation: {

--- a/src/layout/components/app-bar.tsx
+++ b/src/layout/components/app-bar.tsx
@@ -20,7 +20,6 @@ const links = [
   {
     label: "Campaigns",
     url: rootPathnames.CAMPAIGNS,
-    disabled: !["testnet", "staging"].includes(NETWORK),
   },
 
   { label: "Feed", url: rootPathnames.FEED, disabled: false },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The "Campaigns" link in the navigation bar is now always enabled, regardless of the network environment.

- **Chores**
  - Updated the campaigns contract account configuration for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->