### PR TITLE
Updated Staging Contract Keys to Prod

### DIFF
--- a/src/common/_config/staging.env-config.ts
+++ b/src/common/_config/staging.env-config.ts
@@ -10,12 +10,12 @@ export const envConfig: EnvConfig = {
   },
 
   indexer: {
-    api: { endpointUrl: "https://dev.potlock.io" },
+    api: { endpointUrl: "https://api.potlock.io" },
   },
 
   core: {
     donation: {
-      contract: { accountId: "donate.staging.potlock.near" },
+      contract: { accountId: "donate.potlock.near" },
     },
 
     campaigns: {
@@ -23,22 +23,22 @@ export const envConfig: EnvConfig = {
     },
 
     lists: {
-      contract: { accountId: "lists.staging.potlock.near" },
+      contract: { accountId: "lists.potlock.near" },
     },
 
     potFactory: {
-      contract: { accountId: "potfactory.staging.potlock.near" },
+      contract: { accountId: "v1.potfactory.potlock.near" },
     },
 
     sybil: {
       app: { url: "https://staging.nada.bot" },
-      contract: { accountId: "v2new.staging.nadabot.near" },
+      contract: { accountId: "v1.nadabot.near" },
     },
 
     voting: {
       // TODO: Figure out a way to store pot-associated voting contract instances on backend / chain
       //! Be careful when refactoring this
-      contract: { accountId: "mpdao.vote.staging.potlock.near" },
+      contract: { accountId: "mpdao.vote.potlock.near" },
     },
   },
 
@@ -87,3 +87,11 @@ export const envConfig: EnvConfig = {
     },
   },
 };
+
+// KEYS MEANT FOR STAGING
+// 1. donate.staging.potlock.near
+// 2. v1.campaigns.staging.potlock.near
+// 3. lists.staging.potlock.near
+// 4. potfactory.staging.potlock.near
+// 5. v2new.staging.nadabot.near
+// 6. mpdao.vote.staging.potlock.near


### PR DESCRIPTION
Changes were made to make staging look like production apart from the campaigns section, just because staging has empty data, so we're temporary making the keys that of production

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated environment configuration to use production contract account IDs and API endpoints for most services, with the exception of the campaigns contract which remains on staging.
  - Added a comment listing the previous staging-specific contract account IDs for reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->