### PR TITLE
Fix pot application flow for DAOs

### DIFF
--- a/src/common/contracts/core/pot/index.ts
+++ b/src/common/contracts/core/pot/index.ts
@@ -1,7 +1,8 @@
 import * as potContractClient from "./client";
 import * as potContractHooks from "./hooks";
+import * as potContractUtils from "./utils";
 
 export type * from "./hooks";
 export * from "./interfaces";
 
-export { potContractClient, potContractHooks };
+export { potContractClient, potContractHooks, potContractUtils };

--- a/src/common/contracts/core/pot/utils.ts
+++ b/src/common/contracts/core/pot/utils.ts
@@ -1,0 +1,30 @@
+import { calculateDepositByDataSize } from "@wpdas/naxios";
+import { Big } from "big.js";
+
+import { ONE_HUNDREDTH_NEAR } from "@/common/constants";
+import { parseNearAmount } from "@/common/lib";
+import type { IndivisibleUnits } from "@/common/types";
+
+import type { ApplyArgs } from "./client";
+
+type CallDepositParams =
+  | { functionName: "apply"; args: ApplyArgs }
+  | { functionName: string; args: {} };
+
+export const calculateCallDeposit = ({
+  functionName,
+  args,
+}: CallDepositParams): IndivisibleUnits => {
+  switch (functionName) {
+    case "apply": {
+      return (
+        parseNearAmount(Big(0.01).times(calculateDepositByDataSize(args)).toString()) ??
+        ONE_HUNDREDTH_NEAR
+      );
+    }
+
+    default: {
+      return "0";
+    }
+  }
+};

--- a/src/common/contracts/sputnikdao2/client.ts
+++ b/src/common/contracts/sputnikdao2/client.ts
@@ -1,7 +1,8 @@
 import { nearProtocolClient } from "@/common/blockchains/near-protocol";
-import type { ByAccountId } from "@/common/types";
+import { FULL_TGAS } from "@/common/constants";
+import type { ByAccountId, IndivisibleUnits } from "@/common/types";
 
-import type { Policy, ProposalOutput } from "./types";
+import type { Policy, ProposalId, ProposalInput, ProposalOutput } from "./types";
 
 export const get_policy = ({ accountId }: ByAccountId) =>
   nearProtocolClient.naxiosInstance
@@ -20,3 +21,24 @@ export const get_proposals = ({ accountId, args }: ByAccountId & { args: GetProp
   nearProtocolClient.naxiosInstance
     .contractApi({ contractId: accountId })
     .view<typeof args, ProposalOutput[]>("get_proposals", { args });
+
+export type AddProposalArgs = {
+  proposal: ProposalInput;
+};
+
+export const add_proposal = ({
+  accountId,
+  proposalBond,
+  callbackUrl = window.location.href,
+  args,
+}: ByAccountId & { proposalBond: IndivisibleUnits; callbackUrl?: string } & {
+  args: AddProposalArgs;
+}) =>
+  nearProtocolClient.naxiosInstance
+    .contractApi({ contractId: accountId })
+    .call<typeof args, ProposalId>("add_proposal", {
+      args,
+      deposit: proposalBond,
+      gas: FULL_TGAS,
+      callbackUrl,
+    });

--- a/src/common/contracts/sputnikdao2/types.ts
+++ b/src/common/contracts/sputnikdao2/types.ts
@@ -87,7 +87,7 @@ export type ActionCall = {
   args: string;
 
   deposit: IndivisibleUnits;
-  gas: number;
+  gas: IndivisibleUnits;
 };
 
 export enum ProposalStatus {
@@ -148,6 +148,11 @@ export enum Vote {
   Reject = 1,
   Remove = 2,
 }
+
+export type ProposalInput = {
+  description: string;
+  kind: ProposalKind;
+};
 
 export type Proposal = {
   proposer: AccountId;

--- a/src/common/lib/object.ts
+++ b/src/common/lib/object.ts
@@ -1,5 +1,7 @@
 import { mapValues } from "remeda";
 
+import { utf8StringToBase64 } from "./string";
+
 type DeepPartial<T> = T extends object
   ? {
       [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
@@ -52,3 +54,6 @@ export const nullifyEmptyStrings = mapValues((value: string | unknown) => {
     return null;
   } else return value;
 });
+
+export const objectToBase64Json = (obj: object | Record<string, unknown>): string =>
+  utf8StringToBase64(JSON.stringify(obj));

--- a/src/common/lib/string.ts
+++ b/src/common/lib/string.ts
@@ -36,5 +36,10 @@ export const isValidHttpUrl = (value: string) => {
   }
 };
 
-export const utf8StringToBase64 = (value: string): string =>
-  Buffer.from(value, "utf8").toString("base64");
+export const utf8StringToBase64 = (value: string): string => {
+  const encoder = new TextEncoder();
+  const bytes = encoder.encode(value);
+  const binary = bytes.reduce((acc, byte) => acc + String.fromCharCode(byte), "");
+
+  return btoa(binary);
+};

--- a/src/common/lib/string.ts
+++ b/src/common/lib/string.ts
@@ -35,3 +35,6 @@ export const isValidHttpUrl = (value: string) => {
     return false;
   }
 };
+
+export const utf8StringToBase64 = (value: string): string =>
+  Buffer.from(value, "utf8").toString("base64");

--- a/src/features/donation/components/user-entrypoints.tsx
+++ b/src/features/donation/components/user-entrypoints.tsx
@@ -72,7 +72,7 @@ export type DonateToListProjectsProps = ByListId & {};
 export const DonateToListProjects: React.FC<DonateToListProjectsProps> = ({ listId }) => {
   const { openDonationModal } = useDonationUserFlow({ listId });
 
-  return <Button onClick={openDonationModal}>{"Donate to list"}</Button>;
+  return <Button onClick={openDonationModal}>{"Donate to Projects"}</Button>;
 };
 
 export type DonationToCampaignProps = ByCampaignId &

--- a/src/features/matching-pool-contribution/hooks/forms.ts
+++ b/src/features/matching-pool-contribution/hooks/forms.ts
@@ -8,6 +8,7 @@ import { Pot } from "@/common/api/indexer";
 import { naxiosInstance } from "@/common/blockchains/near-protocol/client";
 import { FIFTY_TGAS, FULL_TGAS, MIN_PROPOSAL_DEPOSIT_FALLBACK, ONE_TGAS } from "@/common/constants";
 import { sputnikDaoClient } from "@/common/contracts/sputnikdao2";
+import { objectToBase64Json } from "@/common/lib";
 import { useWalletUserSession } from "@/common/wallet";
 
 import { MatchingPoolContributionInputs, matchingPoolFundingSchema } from "../model/schemas";
@@ -37,7 +38,7 @@ export const useMatchingPoolContributionForm = ({ potDetail }: { potDetail: Pot 
         method_name: "donate",
         gas: FIFTY_TGAS,
         deposit: parseNearAmount(formData.amountNEAR.toString()) || "0",
-        args: Buffer.from(JSON.stringify(args), "utf-8").toString("base64"),
+        args: objectToBase64Json(args),
       };
 
       const daoTransactionArgs = {

--- a/src/features/pot-application/components/PotApplicationModal.tsx
+++ b/src/features/pot-application/components/PotApplicationModal.tsx
@@ -1,28 +1,25 @@
-// TODO!: Import from the UI kit instead and adjust the layout accordingly
-import { Form } from "react-hook-form";
-
-import { Pot } from "@/common/api/indexer";
-import type { AccountId } from "@/common/types";
+import { TextAreaField } from "@/common/ui/form/components";
 import {
   Button,
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
+  Form,
   FormField,
   Spinner,
-  Textarea,
 } from "@/common/ui/layout/components";
 import { useWalletUserSession } from "@/common/wallet";
 
-import { usePotApplicationForm } from "../hooks/forms";
+import { type PotApplicationFormParams, usePotApplicationForm } from "../hooks/forms";
 
-export type PotApplicationModalProps = {
+export type PotApplicationModalProps = Pick<
+  PotApplicationFormParams,
+  "applicantAccountId" | "potConfig" | "onSuccess" | "onFailure"
+> & {
   open?: boolean;
   onCloseClick?: () => void;
-  applicantAccountId: AccountId;
   daoMode?: boolean;
-  potDetail: Pot;
 };
 
 export const PotApplicationModal: React.FC<PotApplicationModalProps> = ({
@@ -30,61 +27,59 @@ export const PotApplicationModal: React.FC<PotApplicationModalProps> = ({
   onCloseClick,
   applicantAccountId,
   daoMode = false,
-  potDetail,
+  potConfig,
+  onSuccess,
+  onFailure,
 }) => {
   const walletUser = useWalletUserSession();
 
-  const { form, errors, onSubmit, inProgress } = usePotApplicationForm({
-    accountId: applicantAccountId,
+  const { form, onSubmit } = usePotApplicationForm({
+    applicantAccountId,
     asDao: daoMode,
-    potDetail,
+    potConfig,
+    onSuccess,
+    onFailure,
   });
 
   return (
     <Dialog open={open}>
       <DialogContent className="max-w-130" onCloseClick={onCloseClick}>
         <DialogHeader>
-          <DialogTitle>Apply to Pot</DialogTitle>
+          <DialogTitle>{`Apply to ${potConfig.name}`}</DialogTitle>
         </DialogHeader>
 
-        <Form {...form} onSubmit={onSubmit}>
-          <div className="flex flex-col p-6">
-            {/*NEAR Input */}
-            <p className="my-2 break-words text-[16px] font-normal leading-[20px] text-neutral-700">
-              Application message <span style={{ color: "#DD3345" }}>*</span>
-            </p>
-
-            {/* Optional Message */}
+        <Form {...form}>
+          <form className="flex flex-col p-6" onSubmit={onSubmit}>
             <FormField
               control={form.control}
               name="message"
               render={({ field }) => (
-                <Textarea
+                <TextAreaField
+                  label="Application Message"
                   placeholder="Your application message here..."
                   rows={5}
                   className="mt-2"
                   {...field}
-                  error={errors.message?.message}
                 />
               )}
             />
 
             <Button
-              disabled={!form.formState.isValid || inProgress}
+              disabled={!form.formState.isValid || form.formState.isSubmitting}
               className="mt-6 min-w-[200px] self-end"
               type="submit"
             >
-              {inProgress ? (
+              {form.formState.isSubmitting ? (
                 <Spinner />
               ) : (
                 <>
                   {walletUser.isDaoRepresentative
-                    ? "Propose to Send Application"
-                    : "Send application"}
+                    ? "Submit Application Proposal"
+                    : "Send Application"}
                 </>
               )}
             </Button>
-          </div>
+          </form>
         </Form>
       </DialogContent>
     </Dialog>

--- a/src/features/pot-application/components/PotApplicationModal.tsx
+++ b/src/features/pot-application/components/PotApplicationModal.tsx
@@ -34,7 +34,6 @@ export const PotApplicationModal: React.FC<PotApplicationModalProps> = ({
 }) => {
   const walletUser = useWalletUserSession();
 
-  // Form settings
   const { form, errors, onSubmit, inProgress } = usePotApplicationForm({
     accountId: applicantAccountId,
     asDao: daoMode,

--- a/src/features/pot-application/hooks/forms.ts
+++ b/src/features/pot-application/hooks/forms.ts
@@ -1,16 +1,13 @@
 import { useCallback, useState } from "react";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { calculateDepositByDataSize } from "@wpdas/naxios";
-import { parseNearAmount } from "near-api-js/lib/utils/format";
-import { FormSubmitHandler, useForm } from "react-hook-form";
+import { FormSubmitHandler, type SubmitHandler, useForm } from "react-hook-form";
 
 import { Pot } from "@/common/api/indexer";
-import { naxiosInstance } from "@/common/blockchains/near-protocol/client";
-import { FULL_TGAS, MIN_PROPOSAL_DEPOSIT_FALLBACK, ONE_TGAS } from "@/common/constants";
 import { potContractClient } from "@/common/contracts/core/pot";
-import { sputnikDaoClient } from "@/common/contracts/sputnikdao2";
+import type { AccountId } from "@/common/types";
 
+import { applyToPot } from "../model/effects";
 import {
   PotApplicationInputs,
   PotApplicationReviewInputs,
@@ -18,99 +15,44 @@ import {
   potApplicationSchema,
 } from "../model/schemas";
 
-export const usePotApplicationForm = ({
-  accountId,
-  potDetail,
-  asDao,
-}: {
-  accountId: string;
-  potDetail: Pot;
+export type PotApplicationFormParams = {
+  applicantAccountId: AccountId;
   asDao: boolean;
-}) => {
-  const form = useForm<PotApplicationInputs>({
+  potConfig: Pot;
+  onSuccess: VoidFunction;
+  onFailure: VoidFunction;
+};
+
+export const usePotApplicationForm = ({
+  applicantAccountId,
+  asDao,
+  potConfig,
+  onSuccess,
+  onFailure,
+}: PotApplicationFormParams) => {
+  const self = useForm<PotApplicationInputs>({
     resolver: zodResolver(potApplicationSchema),
   });
 
-  const [inProgress, setInProgress] = useState(false);
-
-  const onSubmit: FormSubmitHandler<PotApplicationInputs> = useCallback(
-    async (formData) => {
-      const args = {
-        message: formData.data.message,
-      };
-
-      const regularDeposit = "0.01";
-      const extraDeposit = calculateDepositByDataSize(args);
-
-      const deposit = parseNearAmount(
-        (parseFloat(regularDeposit) + parseFloat(extraDeposit)).toString(),
-      )!;
-
-      // if it is a DAO, we need to convert transactions to DAO function call proposals
-      const daoAction = {
-        method_name: "apply",
-        gas: ONE_TGAS,
-        deposit,
-        args: Buffer.from(JSON.stringify(args), "utf-8").toString("base64"),
-      };
-
-      const daoTransactionArgs = {
-        proposal: {
-          proposal: {
-            description: `Application to POTLOCK pot: ${potDetail.name} (${potDetail.account})`,
-            kind: {
-              FunctionCall: {
-                receiver_id: potDetail.account,
-                actions: [daoAction],
-              },
-            },
-          },
-        },
-      };
-
-      // Final - call step
-      // INFO: This is going to take the user to confirm transaction wallet screen
-      const callbackUrl = `${location.origin}${location.pathname}?done=true`;
-
-      try {
-        setInProgress(true);
-
-        if (asDao) {
-          // If Dao, get dao policy
-          const daoPolicy = await sputnikDaoClient.get_policy({ accountId });
-
-          await naxiosInstance
-            .contractApi({ contractId: accountId }) // INFO: In this case, the accountId has daoAddress value
-            .call("add_proposal", {
-              args: daoTransactionArgs,
-              deposit: daoPolicy?.proposal_bond || MIN_PROPOSAL_DEPOSIT_FALLBACK,
-              gas: FULL_TGAS,
-              callbackUrl,
-            });
-        } else {
-          await naxiosInstance
-            .contractApi({ contractId: potDetail.account }) // INFO: In this case, the accountId is a regular pot account
-            .call("apply", {
-              args,
-              deposit,
-              gas: ONE_TGAS.mul(100).toString(),
-              callbackUrl,
-            });
-        }
-      } catch (e) {
-        console.error(e);
-      } finally {
-        setInProgress(false);
-      }
+  const onSubmit: SubmitHandler<PotApplicationInputs> = useCallback(
+    ({ message }) => {
+      applyToPot({ applicantAccountId, asDao, message, potConfig })
+        .then(() => {
+          onSuccess();
+          self.reset();
+        })
+        .catch((err) => {
+          console.error(err);
+          onFailure();
+        });
     },
-    [accountId, asDao, potDetail.account, potDetail.name],
+
+    [applicantAccountId, asDao, onFailure, onSuccess, potConfig, self],
   );
 
   return {
-    form,
-    errors: form.formState.errors,
-    inProgress,
-    onSubmit,
+    form: self,
+    onSubmit: self.handleSubmit(onSubmit),
   };
 };
 

--- a/src/features/pot-application/model/effects.ts
+++ b/src/features/pot-application/model/effects.ts
@@ -1,0 +1,64 @@
+import { PLATFORM_NAME } from "@/common/_config";
+import type { Pot } from "@/common/api/indexer";
+import { nearProtocolClient } from "@/common/blockchains/near-protocol";
+import { FULL_TGAS, ONE_TGAS } from "@/common/constants";
+import { potContractClient, potContractUtils } from "@/common/contracts/core/pot";
+import { sputnikDaoClient } from "@/common/contracts/sputnikdao2";
+import { objectToBase64Json } from "@/common/lib";
+import type { AccountId } from "@/common/types";
+
+export type ApplyParams = potContractClient.ApplyArgs & {
+  applicantAccountId: AccountId;
+  asDao: boolean;
+  potConfig: Pot;
+};
+
+export const applyToPot = ({ applicantAccountId, asDao, message, potConfig }: ApplyParams) => {
+  const applyArgs = {
+    message,
+  };
+
+  if (asDao) {
+    const applyProposalAction = {
+      method_name: "apply",
+      args: objectToBase64Json(applyArgs),
+
+      deposit: potContractUtils.calculateCallDeposit({
+        functionName: "apply",
+        args: applyArgs,
+      }),
+
+      gas: ONE_TGAS,
+    };
+
+    const addApplyProposalArgs = {
+      // FIXME: //! This double nesting is likely the root cause of `#165`
+      proposal: {
+        proposal: {
+          description: `Application to ${potConfig.name} pot on ${
+            PLATFORM_NAME
+          } (${potConfig.account})`,
+
+          kind: {
+            FunctionCall: { receiver_id: potConfig.account, actions: [applyProposalAction] },
+          },
+        },
+      },
+    };
+
+    return sputnikDaoClient
+      .get_policy({ accountId: applicantAccountId })
+      .then(({ proposal_bond }) =>
+        nearProtocolClient.naxiosInstance
+          .contractApi({ contractId: applicantAccountId })
+          .call("add_proposal", {
+            args: addApplyProposalArgs,
+            deposit: proposal_bond,
+            gas: FULL_TGAS,
+            callbackUrl: window.location.href,
+          }),
+      );
+  } else {
+    return potContractClient.apply({ potId: potConfig.account, args: applyArgs });
+  }
+};

--- a/src/features/profile-configuration/models/effects.ts
+++ b/src/features/profile-configuration/models/effects.ts
@@ -20,7 +20,7 @@ import {
 } from "@/common/constants";
 import { type NEARSocialUserProfile } from "@/common/contracts/social-db";
 import { sputnikDaoClient } from "@/common/contracts/sputnikdao2";
-import { deepObjectDiff } from "@/common/lib";
+import { deepObjectDiff, objectToBase64Json } from "@/common/lib";
 import type { ByAccountId } from "@/common/types";
 
 import type { ProfileConfigurationMode } from "../types";
@@ -120,7 +120,7 @@ export const save = async ({
                 method_name: tx.method,
                 gas: tx.gas ?? FIFTY_TGAS,
                 deposit: tx.deposit || "0",
-                args: Buffer.from(JSON.stringify(tx.args), "utf-8").toString("base64"),
+                args: objectToBase64Json(tx.args ?? {}),
               };
 
               return {

--- a/src/layout/pot/components/layout.tsx
+++ b/src/layout/pot/components/layout.tsx
@@ -64,9 +64,12 @@ export const PotLayout: React.FC<PotLayoutProps> = ({ children }) => {
 
     toast({
       title: "Error!",
+
       description: `Unable to submit ${
         walletUser.isDaoRepresentative ? "application proposal" : "application"
       }, please try again.`,
+
+      variant: "destructive",
     });
   }, [toast, walletUser.isDaoRepresentative]);
 

--- a/src/layout/pot/components/layout.tsx
+++ b/src/layout/pot/components/layout.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/router";
 
 import { indexer } from "@/common/api/indexer";
 import { PageWithBanner } from "@/common/ui/layout/components";
+import { useToast } from "@/common/ui/layout/hooks";
 import { cn } from "@/common/ui/layout/utils";
 import { useWalletUserSession } from "@/common/wallet";
 import { ChallengeModal } from "@/entities/pot";
@@ -25,6 +26,7 @@ export type PotLayoutProps = {
 
 export const PotLayout: React.FC<PotLayoutProps> = ({ children }) => {
   const router = useRouter();
+  const { toast } = useToast();
   const walletUser = useWalletUserSession();
 
   const { potId, ...query } = router.query as {
@@ -33,10 +35,6 @@ export const PotLayout: React.FC<PotLayoutProps> = ({ children }) => {
     errorMessage?: string;
   };
 
-  const { activeTab, orderedTabList } = usePotLayoutTabNavigation({ potId });
-  const { data: pot } = indexer.usePot({ potId });
-
-  // Modals
   const [resultModalOpen, setSuccessModalOpen] = useState(!!query.done && !query.errorMessage);
   const [errorModalOpen, setErrorModalOpen] = useState(!!query.errorMessage);
   const [fundModalOpen, setFundModalOpen] = useState(false);
@@ -46,12 +44,38 @@ export const PotLayout: React.FC<PotLayoutProps> = ({ children }) => {
   const [challengeModalOpen, setChallengeModalOpen] = useState(false);
   const openChallengeModal = useCallback(() => setChallengeModalOpen(true), []);
 
+  const { activeTab, orderedTabList } = usePotLayoutTabNavigation({ potId });
+  const { data: pot } = indexer.usePot({ potId });
+
+  const onApplicationSuccess = useCallback(() => {
+    setApplyModalOpen(false);
+
+    toast({
+      title: "Success!",
+
+      description: `Your ${
+        walletUser.isDaoRepresentative ? "application proposal" : "application"
+      } has been submitted.`,
+    });
+  }, [toast, walletUser.isDaoRepresentative]);
+
+  const onApplicationFailure = useCallback(() => {
+    setApplyModalOpen(false);
+
+    toast({
+      title: "Error!",
+      description: `Unable to submit ${
+        walletUser.isDaoRepresentative ? "application proposal" : "application"
+      }, please try again.`,
+    });
+  }, [toast, walletUser.isDaoRepresentative]);
+
   return (
     <PageWithBanner>
       {/**
-       * // TODO!: THIS MODAL IS NOT SUPPOSED TO BE REUSABLE
-       * //! AND MUST BE REPLACED WITH A SIMPLE TOAST CALL
-       * //! THIS IS THE EXACT ROOT CAUSE OF THE POT TRANSACTION CONFIRMATION BUGS
+       * // FIXME:
+       * //! THIS MODAL IS NOT SUPPOSED TO BE REUSABLE
+       * //! AND MUST BE REPLACED WITH AN INDIVIDUAL TOAST CALL FOR EACH USE CASE
        */}
       <SuccessModal
         successMessage="Transaction sent successfully"
@@ -60,9 +84,9 @@ export const PotLayout: React.FC<PotLayoutProps> = ({ children }) => {
       />
 
       {/**
-       * // TODO!: THIS MODAL IS NOT SUPPOSED TO BE REUSABLE
-       * //! AND MUST BE REPLACED WITH A SIMPLE TOAST CALL
-       * //! THIS IS THE EXACT ROOT CAUSE OF THE POT TRANSACTION CONFIRMATION BUGS
+       * // FIXME:
+       * //! THIS MODAL IS NOT SUPPOSED TO BE REUSABLE
+       * //! AND MUST BE REPLACED WITH AN INDIVIDUAL TOAST CALL FOR EACH USE CASE
        */}
       <ErrorModal
         errorMessage={decodeURIComponent(query.errorMessage || "")}
@@ -80,10 +104,12 @@ export const PotLayout: React.FC<PotLayoutProps> = ({ children }) => {
 
           <PotApplicationModal
             open={applyModalOpen}
-            onCloseClick={() => setApplyModalOpen(false)}
             applicantAccountId={walletUser.accountId}
             daoMode={walletUser.isDaoRepresentative}
-            potDetail={pot}
+            potConfig={pot}
+            onCloseClick={() => setApplyModalOpen(false)}
+            onSuccess={onApplicationSuccess}
+            onFailure={onApplicationFailure}
           />
 
           <ChallengeModal


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Apply to a Pot directly or via DAO proposal with automated deposit & gas calculation.
  - New proposal submission helper and a unified apply flow.
  - New utilities for encoding arguments to Base64 and UTF-8-safe strings.

- **UI**
  - Pot Application modal now shows “Apply to {Pot Name}” with clearer labels, submit states, and success/error toasts.
  - “Donate to list” button renamed to “Donate to Projects.”

- **Refactor**
  - Simplified Pot application form API and modal props; submission delegated to a single handler.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->