### PR TITLE
Added success/fail dialogue after changing account status in list

### DIFF
--- a/src/entities/list/components/AccountCard.tsx
+++ b/src/entities/list/components/AccountCard.tsx
@@ -12,6 +12,7 @@ import {
   Button,
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DropdownMenu,
@@ -25,6 +26,7 @@ import {
 } from "@/common/ui/layout/components";
 import DownArrow from "@/common/ui/layout/svg/DownArrow";
 import { ListNoteIcon } from "@/common/ui/layout/svg/list-note";
+import SuccessRedIcon from "@/common/ui/layout/svg/success-red-icon";
 import { cn } from "@/common/ui/layout/utils";
 import {
   ACCOUNT_LIST_REGISTRATION_STATUS_OPTIONS,
@@ -56,6 +58,8 @@ export const ListAccountCard = ({
   );
 
   const [note, setNote] = useState<string>("");
+
+  const [isUpdateSuccessful, setIsUpdateSuccessful] = useState(false);
 
   const status = listRegistrationStatuses[registrationStatus];
 
@@ -100,7 +104,10 @@ export const ListAccountCard = ({
         ...(note && { notes: note }),
         status: statusChange.status as RegistrationStatus,
       })
-      .then((data) => setRegistrationStatus(data.status))
+      .then((data) => {
+        setIsUpdateSuccessful(true);
+        setRegistrationStatus(data.status);
+      })
       .catch((err) => console.error(err));
 
     dispatch.listEditor.handleListToast({
@@ -174,7 +181,10 @@ export const ListAccountCard = ({
               <div className="mt-4 flex items-center justify-between">
                 {accountsWithAccess?.includes(walletApi?.accountId || "") ? (
                   <Select
-                    onValueChange={(value) => setStatusChange({ open: true, status: value })}
+                    onValueChange={(value) => {
+                      setStatusChange({ open: true, status: value });
+                      setIsUpdateSuccessful(false);
+                    }}
                     defaultValue={dataForList.status}
                   >
                     <Trigger asChild>
@@ -218,45 +228,69 @@ export const ListAccountCard = ({
       <Dialog open={statusChange.open}>
         <DialogContent
           onCloseClick={() => {
-            setStatusChange({ open: false });
+            setStatusChange({ open: false, status: "" });
             setNote("");
+            setIsUpdateSuccessful(false);
           }}
         >
           <DialogHeader>
             <DialogTitle>Update Account Status</DialogTitle>
           </DialogHeader>
-
-          <div className="flex flex-col p-6">
-            <p className="text-center">
-              Are you sure you want to change the status of this Account to{" "}
-              <strong>{statusChange.status}?</strong>
-            </p>
-            <Textarea
-              value={note}
-              onChange={(e) => setNote(e.target.value)}
-              className="my-4"
-              placeholder="Add Notes..."
-              rows={4}
-            />
-            <div className="m-8 flex justify-center gap-4">
-              <Button onClick={handleUpdateStatus} variant="standard-outline">
-                Yes, I do
-              </Button>
-              <Button
-                onClick={() => {
-                  setStatusChange({
-                    open: false,
-                    status: statusChange.status,
-                  });
-
-                  setNote("");
-                }}
-                variant="standard-outline"
-              >
-                No, I don&apos;t
-              </Button>
-            </div>
-          </div>
+          <DialogDescription>
+            {isUpdateSuccessful ? (
+              <div className="h-70 flex flex-col items-center justify-center">
+                <div className="flex w-full justify-center">
+                  <SuccessRedIcon />
+                </div>
+                <h2 className="mt-4 text-center text-xl font-semibold">
+                  Account Status Updated Successfully
+                </h2>
+                <p className="mt-2 px-5 text-center text-sm text-gray-500">
+                  The account status has been updated to <strong>{statusChange.status}</strong>.
+                  {note && " Your note has been saved."}
+                </p>
+                <Button
+                  onClick={() => {
+                    setStatusChange({ open: false, status: "" });
+                    setNote("");
+                    setIsUpdateSuccessful(false);
+                  }}
+                  className="mt-8"
+                  variant="standard-outline"
+                >
+                  Close
+                </Button>
+              </div>
+            ) : (
+              <div className="flex flex-col p-6">
+                <p className="text-center">
+                  Are you sure you want to change the status of this Account to{" "}
+                  <strong>{statusChange.status}?</strong>
+                </p>
+                <Textarea
+                  value={note}
+                  onChange={(e) => setNote(e.target.value)}
+                  className="my-4"
+                  placeholder="Add Notes..."
+                  rows={4}
+                />
+                <div className="m-8 flex justify-center gap-4">
+                  <Button onClick={handleUpdateStatus} variant="standard-outline">
+                    Yes, I do
+                  </Button>
+                  <Button
+                    onClick={() => {
+                      setStatusChange({ open: false, status: statusChange.status });
+                      setNote("");
+                    }}
+                    variant="standard-outline"
+                  >
+                    No, I don&apos;t
+                  </Button>
+                </div>
+              </div>
+            )}
+          </DialogDescription>
         </DialogContent>
       </Dialog>
     </>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added success confirmation screen to the account status update flow. When an account status update is completed successfully, users now receive a dedicated visual confirmation screen displaying success feedback and confirmation messaging. The confirmation screen appears before closing the dialog, clearly indicating successful completion.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->