### PR TITLE
Added tooltip for 501c3 verification

### DIFF
--- a/src/features/profile-configuration/components/org-verification-section.tsx
+++ b/src/features/profile-configuration/components/org-verification-section.tsx
@@ -10,7 +10,7 @@ import { Row } from "./editor-elements";
 
 const STATUS_STYLES: Record<string, { bg: string; text: string; label: string }> = {
   Pending: { bg: "bg-[#FFF0E1]", text: "text-[#EA6A25]", label: "Verifying..." },
-  Approved: { bg: "bg-[#E1F5ED]", text: "text-[#0B7A74]", label: "Verified 501(c)(3)" },
+  Approved: { bg: "bg-[#FFF0E1]", text: "text-[#EA6A25]", label: "Unverified 501(c)(3)" },
   Rejected: { bg: "bg-[#FFE1E1]", text: "text-[#ED464F]", label: "Not Verified" },
 };
 
@@ -69,7 +69,7 @@ export const OrgVerificationSection: React.FC<OrgVerificationSectionProps> = ({ 
 
   const statusStyle = verification ? STATUS_STYLES[verification.status] : null;
 
-  // Verified view — show IRS data
+  // Approved view — show IRS data (unverified mode)
   if (verification?.status === "Approved") {
     return (
       <div className="mt-6 flex flex-col gap-4">
@@ -84,6 +84,12 @@ export const OrgVerificationSection: React.FC<OrgVerificationSectionProps> = ({ 
             {statusStyle.label}
           </div>
         )}
+
+        <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+          This data is auto-populated from IRS records. It confirms this EIN belongs to a registered
+          501(c)(3) organization, but does not verify that the submitter is an authorized
+          representative.
+        </div>
 
         <Row>
           <FieldDisplay label="EIN" value={verification.ein} />

--- a/src/layout/profile/components/hero.tsx
+++ b/src/layout/profile/components/hero.tsx
@@ -3,6 +3,7 @@ import { PUBLIC_GOODS_REGISTRY_LIST_ID } from "@/common/constants";
 import { listsContractHooks } from "@/common/contracts/core/lists";
 import { sybilResistanceContractHooks } from "@/common/contracts/core/sybil-resistance";
 import type { ByAccountId } from "@/common/types";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/common/ui/layout/components";
 import { cn } from "@/common/ui/layout/utils";
 import {
   AccountFollowStats,
@@ -89,21 +90,30 @@ export const ProfileLayoutHero: React.FC<ProfileLayoutHeroProps> = ({ accountId 
               )}
 
               {orgVerification?.status === "Approved" && (
-                <div
-                  className={cn(
-                    "bg-background flex items-center gap-1 overflow-hidden rounded-[20px]",
-                    "p-[3px] text-[11px] uppercase tracking-[0.88px] opacity-100",
-                  )}
-                >
-                  {listRegistrationStatusIcons.Approved.icon}
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div
+                      className={cn(
+                        "bg-background flex cursor-help items-center gap-1 overflow-hidden rounded-[20px]",
+                        "p-[3px] text-[11px] uppercase tracking-[0.88px] opacity-100",
+                      )}
+                    >
+                      {listRegistrationStatusIcons.Pending.icon}
 
-                  <div
-                    className="hidden md:block"
-                    style={{ color: listRegistrationStatusIcons.Approved.color }}
-                  >
-                    {"501(c)(3)"}
-                  </div>
-                </div>
+                      <div
+                        className="hidden md:block"
+                        style={{ color: listRegistrationStatusIcons.Pending.color }}
+                      >
+                        {"501(c)(3)"}
+                      </div>
+                    </div>
+                  </TooltipTrigger>
+
+                  <TooltipContent side="bottom" className="max-w-[280px] text-center">
+                    This 501(c)(3) status is auto-populated from IRS records. The submitter has not
+                    been verified as an authorized representative of this organization.
+                  </TooltipContent>
+                </Tooltip>
               )}
             </>
           ) : (


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated 501(c)(3) organization verification status display to show as "Unverified" with amber styling, more accurately representing that auto-populated IRS data does not confirm submitter authorization.

* **Improvements**
  * Added informational callouts and tooltips to organization verification status to clarify that IRS records are auto-populated and do not verify authorized representative status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->