### PR TITLE
Commented docs button

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -24,7 +24,7 @@ import { cn } from "@/common/ui/layout/utils";
 import { WalletUserSessionProvider } from "@/common/wallet";
 import { AppBar } from "@/layout/components/app-bar";
 import { CampaignRouteLoading } from "@/layout/components/campaign-route-loading";
-import { FloatingDocsButton } from "@/layout/components/floating-docs-button";
+// import { FloatingDocsButton } from "@/layout/components/floating-docs-button";
 import { store } from "@/store";
 
 const lora = Lora({
@@ -99,7 +99,7 @@ export default function RootLayout({ Component, pageProps }: AppPropsWithLayout)
             >
               <AppBar />
               <CampaignRouteLoading>{getLayout(<Component {...pageProps} />)}</CampaignRouteLoading>
-              <FloatingDocsButton />
+              {/* <FloatingDocsButton /> */}
             </div>
           </TooltipProvider>
         </NiceModalProvider>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * The floating documentation button has been disabled and is no longer visible in the app interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PotLock/potlock-nextjs-app/pull/634?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->